### PR TITLE
multiple weighting windows for VirtualFusedVolume

### DIFF
--- a/zetastitcher/fuse/fuse.py
+++ b/zetastitcher/fuse/fuse.py
@@ -144,7 +144,7 @@ def fuse_queue(q, dest, frame_shape, weighting_mode="squircle_alpha", debug=Fals
                     if not area:
                         continue
                     
-                    w = xy_weights(*frame_shape)[:height, :width]
+                    w = xy_weights[:height, :width]
 
                     if row.X_from == 0:
                         w = np.fliplr(w)

--- a/zetastitcher/fuse/fuse.py
+++ b/zetastitcher/fuse/fuse.py
@@ -143,8 +143,8 @@ def fuse_queue(q, dest, frame_shape, weighting_mode="squircle_alpha", debug=Fals
                     area = width * height
                     if not area:
                         continue
-
-                    w = squircle_alpha(*frame_shape)[:height, :width]
+                    
+                    w = xy_weights(*frame_shape)[:height, :width]
 
                     if row.X_from == 0:
                         w = np.fliplr(w)

--- a/zetastitcher/fuse/fuse.py
+++ b/zetastitcher/fuse/fuse.py
@@ -68,7 +68,7 @@ def squircle_alpha(height, width):
     return squircle
 
 
-def fuse_queue(q, dest, frame_shape, debug=False):
+def fuse_queue(q, dest, frame_shape, weighting_mode="squircle_alpha", debug=False):
     """Fuse a queue of images along Y, optionally applying padding.
 
     Parameters
@@ -87,6 +87,9 @@ def fuse_queue(q, dest, frame_shape, debug=False):
         Shape of a stack plane (XY).
     dest : :class:`numpy.ndarray`
         Destination array.
+    weighting_mode : str
+        Weighting mode, defines the weighting window used to fuse overlapping slices.
+        Currently only ``squircle_alpha`` and ``none`` are supported.
     debug: bool
         Whether to overlay debug information (tile edges and numbers).
     """
@@ -113,7 +116,12 @@ def fuse_queue(q, dest, frame_shape, debug=False):
             z = np.unique(z)
             z = np.sort(z)
 
-            xy_weights = squircle_alpha(*frame_shape)
+            if weighting_mode == "squircle_alpha":
+                xy_weights = squircle_alpha(*frame_shape)
+            elif weighting_mode == "none":
+                xy_weights = np.ones(frame_shape)
+            else:
+                raise ValueError("Unknown weighting mode: {}".format(weighting_mode))
 
             z_list = list(zip(z, z[1::]))
             try:

--- a/zetastitcher/fuse/virtual_fused_volume.py
+++ b/zetastitcher/fuse/virtual_fused_volume.py
@@ -48,7 +48,7 @@ class VirtualFusedVolume:
         ('0100_0000.tiff', (slice(40, 41, 1), slice(1000, 1500, 1), slice(0, 453, 1))),
     ]
     """
-    def __init__(self, file_or_matrix):
+    def __init__(self, file_or_matrix, weighting_mode: str = 'squircle_alpha'):
         if isinstance(file_or_matrix, str):
             self.path, _ = os.path.split(file_or_matrix)
             self.fm = FileMatrix(file_or_matrix)
@@ -78,7 +78,10 @@ class VirtualFusedVolume:
             self.nchannels = f.nchannels
 
         self.squeeze_enabled = True
-
+        self.weighting_mode = weighting_mode
+        if self.weighting_mode not in ['squircle_alpha', 'none']:
+            raise ValueError('Invalid weighting mode: {}'.format(self.weighting_mode))
+    
     @property
     def overlay_debug_enabled(self):
         """Whether to overlay debug information (tile edges and numbers).
@@ -229,6 +232,7 @@ class VirtualFusedVolume:
             args=(q, fused, self.temp_shape[-2::]),
             kwargs={
                 'debug': self._debug,
+                'weighting_mode': self.weighting_mode,
             }
         )
         t.start()


### PR DESCRIPTION
Adding the possibility to choose a weighting window for VirtualFusedVolume. 
Using a constant window is useful when using VirtualFusedVolume with non-overlapping stacks.